### PR TITLE
fix typo in php service item

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -3,7 +3,7 @@
   hosts: default
   handlers:
     - name: restart web
-      with_items: [nginx, php7-fpm]
+      with_items: [nginx, php7.0-fpm]
       service: name={{ item }} state=restarted
 
   tasks:


### PR DESCRIPTION
The ansible provisioner failed with the following error:

`RUNNING HANDLER [restart web] **************************************************
changed: [default] => (item=nginx)
failed: [default] (item=php7-fpm) => {"failed": true, "item": "php7-fpm", "msg": "no service or tool found for: php7-fpm"}`

This tiny change fixes it!