### PR TITLE
use own phpunit instead of phpunit provided by Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - composer install
 
 script:
-  - phpunit --exclude-group=none
+  - ./vendor/bin/phpunit --exclude-group=none
 
 services:
   - elasticsearch


### PR DESCRIPTION
fixes errors with PHPUnit 6 on Travis CI.

see https://travis-ci.org/broadway/broadway-demo/jobs/213361455